### PR TITLE
add alarm manager and receiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver android:name=".receiver.AlarmReceiver" />
     </application>
 
 </manifest>

--- a/app/src/main/java/edu/uc/hickmadc/customnotifications/Constants.kt
+++ b/app/src/main/java/edu/uc/hickmadc/customnotifications/Constants.kt
@@ -1,0 +1,5 @@
+package edu.uc.hickmadc.customnotifications
+
+object Constants {
+    const val CUSTOM_NOTIFICATIONS_CHANNEL = "133712345"
+}

--- a/app/src/main/java/edu/uc/hickmadc/customnotifications/MainActivity.kt
+++ b/app/src/main/java/edu/uc/hickmadc/customnotifications/MainActivity.kt
@@ -1,18 +1,15 @@
 package edu.uc.hickmadc.customnotifications
 
-import android.annotation.SuppressLint
-import androidx.appcompat.app.AppCompatActivity
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import android.os.Bundle
-import android.widget.Button
-import android.widget.ImageButton
-import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.Navigation
 import androidx.navigation.findNavController
 import androidx.navigation.ui.NavigationUI
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import edu.uc.hickmadc.customnotifications.ui.main.MyListAdapter
-import edu.uc.hickmadc.customnotifications.ui.main.dialogfragment
-
+import edu.uc.hickmadc.customnotifications.Constants.CUSTOM_NOTIFICATIONS_CHANNEL
 
 class MainActivity : AppCompatActivity() {
 
@@ -24,6 +21,7 @@ class MainActivity : AppCompatActivity() {
 
         if (savedInstanceState == null) {
             setupBottomNavigationBar()
+            createNotificationChannel()
         }
     }
 
@@ -45,5 +43,18 @@ class MainActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         val navController = findNavController(R.id.nav_host_fragment)
         return navController.navigateUp() || super.onSupportNavigateUp()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CUSTOM_NOTIFICATIONS_CHANNEL,
+            "All Custom Notifications",
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = "All notifications"
+        }
+        val notificationManager: NotificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/edu/uc/hickmadc/customnotifications/receiver/AlarmReceiver.kt
+++ b/app/src/main/java/edu/uc/hickmadc/customnotifications/receiver/AlarmReceiver.kt
@@ -1,0 +1,34 @@
+package edu.uc.hickmadc.customnotifications.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import edu.uc.hickmadc.customnotifications.Constants.CUSTOM_NOTIFICATIONS_CHANNEL
+import edu.uc.hickmadc.customnotifications.R
+
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent) {
+        createNotification(
+            context,
+            intent.getStringExtra("EXTRA_NOTIFICATION_TITLE")!!,
+            intent.getStringExtra("EXTRA_NOTIFICATION_DESC")!!,
+            intent.getIntExtra("EXTRA_NOTIFICATION_ID", 0)
+        )
+    }
+
+    private fun createNotification(context: Context?, title: String, desc: String, notificationId: Int) {
+        if (context != null) {
+            val builder = NotificationCompat.Builder(context, CUSTOM_NOTIFICATIONS_CHANNEL)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle(title)
+                .setContentText(desc)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            with(NotificationManagerCompat.from(context)) {
+                notify(notificationId, builder.build())
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/edu/uc/hickmadc/customnotifications/service/AlarmService.kt
+++ b/app/src/main/java/edu/uc/hickmadc/customnotifications/service/AlarmService.kt
@@ -1,0 +1,31 @@
+package edu.uc.hickmadc.customnotifications.service
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import edu.uc.hickmadc.customnotifications.dto.Notification
+import edu.uc.hickmadc.customnotifications.receiver.AlarmReceiver
+
+class AlarmService(private val context: Context) {
+    private val alarmManager: AlarmManager? =
+        context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+    private lateinit var alarmIntent: PendingIntent
+
+    fun setSingleAlarm(triggerMillis: Long, notification: Notification) {
+        alarmIntent = Intent(context, AlarmReceiver::class.java).let { intent ->
+            with(intent) {
+                putExtra("EXTRA_NOTIFICATION_TITLE", notification.title)
+                putExtra("EXTRA_NOTIFICATION_DESC", notification.desc)
+                putExtra("EXTRA_NOTIFICATION_ID", notification.notificationId)
+            }
+            PendingIntent.getBroadcast(context, 0, intent, 0)
+        }
+        alarmManager?.set(
+            AlarmManager.ELAPSED_REALTIME_WAKEUP,
+            SystemClock.elapsedRealtime() + triggerMillis,
+            alarmIntent
+        )
+    }
+}


### PR DESCRIPTION
Provides groundwork for showing a basic notification on an alarm

Doesn't support repeating alarms yet and is not connected to the UI at all

### Changes
1. AlarmManager sets up alarm timing
2. AlarmReceiver handles what happens when the alarm triggers (shows notification)
3. Notification channel is set up in main activity on start up

to see in action, checkout the branch and add the following to `MainFragment.kt` in `onCreateView()`
```kotlin
AlarmService(requireContext()).setSingleAlarm(
    5000,
    Notification("Hello World", "", "this is the body text")
)
```
it should show a notification after 5 seconds every time you navigate to the notifications page

related to #40 but not complete enough to close